### PR TITLE
Fix background process pid bug

### DIFF
--- a/lvm_backup.sh
+++ b/lvm_backup.sh
@@ -758,7 +758,7 @@ mount_and_backup() {
 
             (set -xe;
                 tar --exclude "./lost+found" -C "$mount_dir" -cvf "$tar_file" .;
-            )
+            ) &
             CL_BACKUP_PID=$!
             set +e
             wait "$CL_BACKUP_PID"


### PR DESCRIPTION
This fixes a bug I encountered where the `$!` would be empty due to the previous line not being created as a background process.